### PR TITLE
[feat] 회원 도메인 엔티티 구현 및 테스트 환경 기본 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 
 	// dotenv-java
 	implementation 'io.github.cdimascio:java-dotenv:+'
+
+	// testcontainers
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mysql'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/jo0oy/cafeorder/user/User.java
+++ b/src/main/java/com/jo0oy/cafeorder/user/User.java
@@ -1,0 +1,40 @@
+package com.jo0oy.cafeorder.user;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user")
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String username;
+
+    @Column(nullable = false, length = 150)
+    private String password;
+
+    @Column(nullable = false, length = 30)
+    private String phoneNumber;
+
+    @Builder
+    private User(
+        Long id,
+        String username,
+        String password,
+        String phoneNumber
+    ) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/com/jo0oy/cafeorder/user/UserRepository.java
+++ b/src/main/java/com/jo0oy/cafeorder/user/UserRepository.java
@@ -1,0 +1,6 @@
+package com.jo0oy.cafeorder.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/test/java/com/jo0oy/cafeorder/config/DatabaseCleanAfterEach.java
+++ b/src/test/java/com/jo0oy/cafeorder/config/DatabaseCleanAfterEach.java
@@ -1,0 +1,15 @@
+package com.jo0oy.cafeorder.config;
+
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(DatabaseCleanAfterEachExtension.class)
+public @interface DatabaseCleanAfterEach {
+}

--- a/src/test/java/com/jo0oy/cafeorder/config/DatabaseCleanAfterEachExtension.java
+++ b/src/test/java/com/jo0oy/cafeorder/config/DatabaseCleanAfterEachExtension.java
@@ -1,0 +1,52 @@
+package com.jo0oy.cafeorder.config;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+public class DatabaseCleanAfterEachExtension implements AfterEachCallback {
+
+    @Override
+    @Transactional
+    public void afterEach(ExtensionContext context) throws Exception {
+        var applicationContext = SpringExtension.getApplicationContext(context);
+        var jdbcTemplate = applicationContext.getBean(JdbcTemplate.class);
+
+        try (var connection = Objects.requireNonNull(Objects.requireNonNull(jdbcTemplate.getDataSource()).getConnection())) {
+            var rs = connection.getMetaData().getTables(null, null, "%", new String[]{"TABLE"});
+
+            executeResetTableQuery(jdbcTemplate, rs);
+
+        } catch (Exception exception) {
+            throw new RuntimeException("database table clean error");
+        }
+    }
+
+    private void executeResetTableQuery(JdbcTemplate jdbcTemplate, ResultSet rs) throws SQLException {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+        while (rs.next()) {
+            var tableName = rs.getString("TABLE_NAME");
+            jdbcTemplate.execute(createTruncateTableQuery(tableName));
+            jdbcTemplate.execute(createResetAutoIncrementQuery(tableName));
+        }
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+    }
+
+    private String createTruncateTableQuery(String tableName) {
+        return "TRUNCATE TABLE " + tableName;
+    }
+
+    private String createResetAutoIncrementQuery(String tableName) {
+
+        return "ALTER TABLE " + tableName + " AUTO_INCREMENT = 1";
+    }
+
+}

--- a/src/test/java/com/jo0oy/cafeorder/user/UserRepositoryTest.java
+++ b/src/test/java/com/jo0oy/cafeorder/user/UserRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.jo0oy.cafeorder.user;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void saveUserTest() {
+        //given
+        var user = User.builder()
+            .username("user1")
+            .password("user1pwd")
+            .phoneNumber("010-1111-1111")
+            .build();
+
+        //when
+        User savedUser = userRepository.save(user);
+
+        //then
+        assertThat(savedUser.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void findByIdTest() {
+        //given
+        var user = User.builder()
+            .username("user1")
+            .password("user1pwd")
+            .phoneNumber("010-1111-1111")
+            .build();
+
+        User savedUser = userRepository.save(user);
+
+        //when
+        Optional<User> findUser = userRepository.findById(savedUser.getId());
+
+        //then
+        assertThat(findUser).isPresent();
+        assertThat(findUser.get().getId()).isEqualTo(savedUser.getId());
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8.0:///
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
- 회원 (User) 엔티티 구현

- UserRepository 구현

- `@DatabaseCleanAfterEach` 애노테이션 생성

- mysql testcontainers를 위해 의존성 추가

- test 프로파일 DB, JPA 기본 설정

This close #4 